### PR TITLE
Add User-Agent header for MCP tracking and getQueryHistory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Works with Claude desktop app. Implements two MCP [tools](https://modelcontextpr
 
 - queryApl: Execute APL queries against Axiom datasets
 - listDatasets: List available Axiom datasets
+- getDatasetSchema: Get dataset schema
+- getSavedQueries: Retrieve saved/starred APL queries
+- getMonitors: List monitoring configurations
+- getMonitorsHistory: Get monitor execution history
+- getQueryHistory: Get your recent APL query execution history (shows your queries by default)
+
+**Note:** getQueryHistory tools require a Personal Access Token (PAT) in addition to the regular API token.
 
 No support for MCP [resources](https://modelcontextprotocol.io/docs/concepts/resources) or [prompts](https://modelcontextprotocol.io/docs/concepts/prompts) yet.
 
@@ -30,6 +37,7 @@ Configure using one of these methods:
 ### Config File Example (config.txt):
 ```txt
 token xaat-your-token
+pat xapt-your-personal-access-token
 url https://api.axiom.co
 org-id your-org-id
 query-rate 1
@@ -42,6 +50,7 @@ datasets-burst 1
 ```bash
 axiom-mcp \
   -token xaat-your-token \
+  -pat xapt-your-personal-access-token \
   -url https://api.axiom.co \
   -org-id your-org-id \
   -query-rate 1 \
@@ -53,6 +62,7 @@ axiom-mcp \
 ### Environment Variables:
 ```bash
 export AXIOM_TOKEN=xaat-your-token
+export AXIOM_PAT=xapt-your-personal-access-token
 export AXIOM_URL=https://api.axiom.co
 export AXIOM_ORG_ID=your-org-id
 export AXIOM_QUERY_RATE=1
@@ -82,6 +92,7 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
       "args" : ["--config", "/path/to/your/config.txt"],
       "env": { // Alternatively, you can set the environment variables here
         "AXIOM_TOKEN": "xaat-your-token",
+        "AXIOM_PAT": "xapt-your-personal-access-token",
         "AXIOM_URL": "https://api.axiom.co",
         "AXIOM_ORG_ID": "your-org-id"
       }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) server implementati
 
 ## Status
 
-Works with Claude desktop app. Implements two MCP [tools](https://modelcontextprotocol.io/docs/concepts/tools):
+Works with Claude desktop app. Implements seven MCP [tools](https://modelcontextprotocol.io/docs/concepts/tools):
 
 - queryApl: Execute APL queries against Axiom datasets
 - listDatasets: List available Axiom datasets
@@ -14,7 +14,7 @@ Works with Claude desktop app. Implements two MCP [tools](https://modelcontextpr
 - getMonitorsHistory: Get monitor execution history
 - getQueryHistory: Get your recent APL query execution history (shows your queries by default)
 
-**Note:** getQueryHistory tools require a Personal Access Token (PAT) in addition to the regular API token.
+**Note:** All tools require a Personal Access Token (PAT) for authentication.
 
 No support for MCP [resources](https://modelcontextprotocol.io/docs/concepts/resources) or [prompts](https://modelcontextprotocol.io/docs/concepts/prompts) yet.
 
@@ -36,7 +36,6 @@ Configure using one of these methods:
 
 ### Config File Example (config.txt):
 ```txt
-token xaat-your-token
 pat xapt-your-personal-access-token
 url https://api.axiom.co
 org-id your-org-id
@@ -49,7 +48,6 @@ datasets-burst 1
 ### Command Line Flags:
 ```bash
 axiom-mcp \
-  -token xaat-your-token \
   -pat xapt-your-personal-access-token \
   -url https://api.axiom.co \
   -org-id your-org-id \
@@ -61,7 +59,6 @@ axiom-mcp \
 
 ### Environment Variables:
 ```bash
-export AXIOM_TOKEN=xaat-your-token
 export AXIOM_PAT=xapt-your-personal-access-token
 export AXIOM_URL=https://api.axiom.co
 export AXIOM_ORG_ID=your-org-id
@@ -75,7 +72,7 @@ export AXIOM_DATASETS_BURST=1
 
 1. Create a config file:
 ```bash
-echo "token xaat-your-token" > config.txt
+echo "pat xapt-your-personal-access-token" > config.txt
 ```
 
 2. Configure the Claude app to use the MCP server:
@@ -91,7 +88,6 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
       "command": "/path/to/your/axiom-mcp-binary",
       "args" : ["--config", "/path/to/your/config.txt"],
       "env": { // Alternatively, you can set the environment variables here
-        "AXIOM_TOKEN": "xaat-your-token",
         "AXIOM_PAT": "xapt-your-personal-access-token",
         "AXIOM_URL": "https://api.axiom.co",
         "AXIOM_ORG_ID": "your-org-id"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Works with Claude desktop app. Implements seven MCP [tools](https://modelcontext
 - getMonitorsHistory: Get monitor execution history
 - getQueryHistory: Get your recent APL query execution history (shows your queries by default)
 
-**Note:** All tools require a Personal Access Token (PAT) for authentication.
+**Note:** All tools require a Personal Access Token (PAT) for authentication. Use your PAT as the `token` parameter.
 
 No support for MCP [resources](https://modelcontextprotocol.io/docs/concepts/resources) or [prompts](https://modelcontextprotocol.io/docs/concepts/prompts) yet.
 
@@ -36,7 +36,7 @@ Configure using one of these methods:
 
 ### Config File Example (config.txt):
 ```txt
-pat xapt-your-personal-access-token
+token xapt-your-personal-access-token
 url https://api.axiom.co
 org-id your-org-id
 query-rate 1
@@ -48,7 +48,7 @@ datasets-burst 1
 ### Command Line Flags:
 ```bash
 axiom-mcp \
-  -pat xapt-your-personal-access-token \
+  -token xapt-your-personal-access-token \
   -url https://api.axiom.co \
   -org-id your-org-id \
   -query-rate 1 \
@@ -59,7 +59,7 @@ axiom-mcp \
 
 ### Environment Variables:
 ```bash
-export AXIOM_PAT=xapt-your-personal-access-token
+export AXIOM_TOKEN=xapt-your-personal-access-token
 export AXIOM_URL=https://api.axiom.co
 export AXIOM_ORG_ID=your-org-id
 export AXIOM_QUERY_RATE=1
@@ -72,7 +72,7 @@ export AXIOM_DATASETS_BURST=1
 
 1. Create a config file:
 ```bash
-echo "pat xapt-your-personal-access-token" > config.txt
+echo "token xapt-your-personal-access-token" > config.txt
 ```
 
 2. Configure the Claude app to use the MCP server:
@@ -88,7 +88,7 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
       "command": "/path/to/your/axiom-mcp-binary",
       "args" : ["--config", "/path/to/your/config.txt"],
       "env": { // Alternatively, you can set the environment variables here
-        "AXIOM_PAT": "xapt-your-personal-access-token",
+        "AXIOM_TOKEN": "xapt-your-personal-access-token",
         "AXIOM_URL": "https://api.axiom.co",
         "AXIOM_ORG_ID": "your-org-id"
       }

--- a/main.go
+++ b/main.go
@@ -43,7 +43,6 @@ var (
 // config holds the server configuration parameters
 type config struct {
 	// Axiom connection settings
-	token string // API token for authentication
 	pat   string // Personal Access Token
 	url   string // Optional custom API URL
 	orgID string // Organization ID
@@ -62,7 +61,6 @@ func setupConfig() (config, error) {
 	fs := flag.NewFlagSet("axiom-mcp", flag.ExitOnError)
 
 	var cfg config
-	fs.StringVar(&cfg.token, "token", "", "Axiom API token")
 	fs.StringVar(&cfg.pat, "pat", "", "Axiom Personal Access Token")
 	fs.StringVar(&cfg.url, "url", "", "Axiom API URL (optional)")
 	fs.StringVar(&cfg.orgID, "org-id", "", "Axiom organization ID")
@@ -85,8 +83,8 @@ func setupConfig() (config, error) {
 		return cfg, fmt.Errorf("failed to parse configuration: %w", err)
 	}
 
-	if cfg.token == "" {
-		return cfg, errors.New("Axiom token must be provided via -token flag, AXIOM_TOKEN env var, or config file")
+	if cfg.pat == "" {
+		return cfg, errors.New("Axiom Personal Access Token (PAT) must be provided via -pat flag, AXIOM_PAT env var, or config file")
 	}
 
 	return cfg, nil

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 // config holds the server configuration parameters
 type config struct {
 	// Axiom connection settings
-	pat   string // Personal Access Token
+	token string // Personal Access Token (PAT)
 	url   string // Optional custom API URL
 	orgID string // Organization ID
 
@@ -61,7 +61,7 @@ func setupConfig() (config, error) {
 	fs := flag.NewFlagSet("axiom-mcp", flag.ExitOnError)
 
 	var cfg config
-	fs.StringVar(&cfg.pat, "pat", "", "Axiom Personal Access Token")
+	fs.StringVar(&cfg.token, "token", "", "Axiom Personal Access Token (PAT)")
 	fs.StringVar(&cfg.url, "url", "", "Axiom API URL (optional)")
 	fs.StringVar(&cfg.orgID, "org-id", "", "Axiom organization ID")
 	fs.Float64Var(&cfg.queryRateLimit, "query-rate", 1, "Queries per second limit")
@@ -83,8 +83,8 @@ func setupConfig() (config, error) {
 		return cfg, fmt.Errorf("failed to parse configuration: %w", err)
 	}
 
-	if cfg.pat == "" {
-		return cfg, errors.New("Axiom Personal Access Token (PAT) must be provided via -pat flag, AXIOM_PAT env var, or config file")
+	if cfg.token == "" {
+		return cfg, errors.New("Axiom Personal Access Token (PAT) must be provided via -token flag, AXIOM_TOKEN env var, or config file")
 	}
 
 	return cfg, nil

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var (
 type config struct {
 	// Axiom connection settings
 	token string // API token for authentication
+	pat   string // Personal Access Token
 	url   string // Optional custom API URL
 	orgID string // Organization ID
 
@@ -62,6 +63,7 @@ func setupConfig() (config, error) {
 
 	var cfg config
 	fs.StringVar(&cfg.token, "token", "", "Axiom API token")
+	fs.StringVar(&cfg.pat, "pat", "", "Axiom Personal Access Token")
 	fs.StringVar(&cfg.url, "url", "", "Axiom API URL (optional)")
 	fs.StringVar(&cfg.orgID, "org-id", "", "Axiom organization ID")
 	fs.Float64Var(&cfg.queryRateLimit, "query-rate", 1, "Queries per second limit")

--- a/tools.go
+++ b/tools.go
@@ -39,7 +39,7 @@ func createTools(cfg config) ([]mcp.ToolDefinition, error) {
 	httpClient := createAxiomHTTPClient()
 
 	client, err := axiom.NewClient(
-		axiom.SetToken(cfg.pat),
+		axiom.SetToken(cfg.token),
 		axiom.SetURL(cfg.url),
 		axiom.SetOrganizationID(cfg.orgID),
 		axiom.SetClient(httpClient),
@@ -361,7 +361,7 @@ func newGetSavedQueriesHandler(cfg config, httpClient *http.Client) func(mcp.Cal
 			return mcp.CallToolResult{}, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		req.Header.Set("Authorization", "Bearer "+cfg.pat)
+		req.Header.Set("Authorization", "Bearer "+cfg.token)
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-AXIOM-ORG-ID", cfg.orgID)
 
@@ -424,7 +424,7 @@ func newGetMonitorsHandler(cfg config, httpClient *http.Client) func(mcp.CallToo
 			return mcp.CallToolResult{}, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		req.Header.Set("Authorization", "Bearer "+cfg.pat)
+		req.Header.Set("Authorization", "Bearer "+cfg.token)
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-AXIOM-ORG-ID", cfg.orgID)
 
@@ -503,7 +503,7 @@ func newGetMonitorsHistoryHandler(cfg config, httpClient *http.Client) func(mcp.
 			return mcp.CallToolResult{}, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		req.Header.Set("Authorization", "Bearer "+cfg.pat)
+		req.Header.Set("Authorization", "Bearer "+cfg.token)
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-AXIOM-ORG-ID", cfg.orgID)
 
@@ -558,7 +558,7 @@ func newGetMonitorsHistoryHandler(cfg config, httpClient *http.Client) func(mcp.
 func getCurrentUserId(cfg config, httpClient *http.Client) (string, error) {
 	ctx := context.Background()
 
-	if cfg.pat == "" {
+	if cfg.token == "" {
 		return "", fmt.Errorf("personal Access Token (PAT) is required")
 	}
 
@@ -570,7 +570,7 @@ func getCurrentUserId(cfg config, httpClient *http.Client) (string, error) {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+cfg.pat)
+	req.Header.Set("Authorization", "Bearer "+cfg.token)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-AXIOM-ORG-ID", cfg.orgID)
 

--- a/tools.go
+++ b/tools.go
@@ -572,7 +572,6 @@ func getCurrentUserId(cfg config, httpClient *http.Client) (string, error) {
 
 	req.Header.Set("Authorization", "Bearer "+cfg.token)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-AXIOM-ORG-ID", cfg.orgID)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -589,17 +588,18 @@ func getCurrentUserId(cfg config, httpClient *http.Client) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
-
-	var userResponse map[string]interface{}
+	var userResponse struct {
+		ID string `json:"id"`
+	}
 	if err := json.Unmarshal(body, &userResponse); err != nil {
 		return "", fmt.Errorf("failed to parse user response: %w", err)
 	}
 
-	if userID, ok := userResponse["id"].(string); ok && userID != "" {
-		return userID, nil
+	if userResponse.ID == "" {
+		return "", fmt.Errorf("user ID not found in response")
 	}
 
-	return "", fmt.Errorf("user ID not found in response")
+	return userResponse.ID, nil
 }
 
 // newGetQueryHistoryHandler creates a handler for retrieving query execution history from axiom-history dataset


### PR DESCRIPTION
- Add custom HTTP transport to set User-Agent header for all Axiom API requests
- Implement getQueryHistory tool to retrieve APL query execution history (requires PAT)