### PR TITLE
Use axiom client features instead of custom implementations

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -355,7 +355,7 @@ func newGetMonitorsHistoryHandler(cfg config, httpClient *http.Client) func(mcp.
 			return mcp.CallToolResult{}, fmt.Errorf("monitorIds parameter is required")
 		}
 
-		monitorIdsSlice, ok := monitorIdsRaw.([]interface{})
+		monitorIdsSlice, ok := monitorIdsRaw.([]any)
 		if !ok {
 			return mcp.CallToolResult{}, fmt.Errorf("monitorIds must be an array")
 		}


### PR DESCRIPTION
This PR refactors the codebase to use built-in axiom-go client features instead of custom implementations, improving maintainability and following SDK best practices.

## Changes

### Replace custom transport with axiom.SetUserAgent() option
- Removes custom `mcpTransport` struct and `createAxiomHTTPClient()` function (~15 lines of code)
- Uses the official `axiom.SetUserAgent(MCP_USER_AGENT)` option in client configuration
- Maintains the same user agent functionality while following the established axiom-go SDK pattern

### Refactor newGetMonitorsHandler to use SDK method
- Changes function signature to accept `*axiom.Client` instead of `config` and `*http.Client`
- Replaces manual HTTP request handling with `client.Monitors.List()` SDK method
- Removes manual request creation, header setting, and response parsing
- Simplifies implementation and maintains consistency with axiom-go client patterns

## Benefits
- **Cleaner code**: Removes custom transport implementation
- **Better maintainability**: Uses official SDK methods instead of manual HTTP calls
- **Consistency**: Follows established axiom-go configuration and usage patterns
- **Reduced complexity**: Eliminates manual request/response handling

Both changes maintain the exact same functionality while leveraging the axiom-go client's built-in capabilities.